### PR TITLE
팀 관리 Swagger 3 설정 및 팀-사용자 할당/해제 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,25 +29,22 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-//	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
-
-
-
-
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/studycrew/studycrew_backend/api/team/TeamManagementController.java
+++ b/src/main/java/com/studycrew/studycrew_backend/api/team/TeamManagementController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin")
+@RequestMapping("/management")
 @Validated
 public class TeamManagementController {
 

--- a/src/main/java/com/studycrew/studycrew_backend/api/team/TeamManagementController.java
+++ b/src/main/java/com/studycrew/studycrew_backend/api/team/TeamManagementController.java
@@ -24,6 +24,12 @@ public class TeamManagementController {
         return ResponseEntity.ok(teamDto);
     }
 
+    @GetMapping("/teams/{teamId}")
+    public ResponseEntity<?> findTeamById(@PathVariable @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId) {
+        TeamDto teamDto = teamManagementService.findTeamById(teamId);
+        return ResponseEntity.ok(teamDto);
+    }
+
     @PostMapping("/delete/{ownerId}/{teamId}")
     public ResponseEntity<?> delete(@PathVariable @Valid @Positive(message = "사용자 아이디는 1 이상이어야 합니다.") Long ownerId,
                                     @PathVariable @Valid @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId) {

--- a/src/main/java/com/studycrew/studycrew_backend/api/team/TeamManagementController.java
+++ b/src/main/java/com/studycrew/studycrew_backend/api/team/TeamManagementController.java
@@ -3,6 +3,12 @@ package com.studycrew.studycrew_backend.api.team;
 import com.studycrew.studycrew_backend.domain.profile.team.dto.TeamDto;
 import com.studycrew.studycrew_backend.domain.profile.team.dto.TeamRegistrationDto;
 import com.studycrew.studycrew_backend.domain.profile.team.service.TeamManagementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Team Management Controller", description = "팀 생성, 삭제 및 조회 API 제공")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/management")
@@ -18,18 +25,36 @@ public class TeamManagementController {
 
     private final TeamManagementService teamManagementService;
 
+    @Operation(summary = "팀 생성", description = "팀을 생성한 사용자가 팀 리더로 설정됩니다. (변경 가능)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀 생성 성공", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "400", description = "알 수 없는 사용자이거나, 요청한 사용자가 이미 다른 팀 리더이면 팀 생성 불가", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생", content = @Content(schema = @Schema(implementation = Exception.class)))
+    })
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody @Valid TeamRegistrationDto teamRegistrationDto) {
         TeamDto teamDto = teamManagementService.register(teamRegistrationDto);
         return ResponseEntity.ok(teamDto);
     }
 
+    @Operation(summary = "팀 조회", description = "팀 ID로 팀 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀 조회 성공", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 팀", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생", content = @Content(schema = @Schema(implementation = Exception.class)))
+    })
     @GetMapping("/teams/{teamId}")
     public ResponseEntity<?> findTeamById(@PathVariable @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId) {
         TeamDto teamDto = teamManagementService.findTeamById(teamId);
         return ResponseEntity.ok(teamDto);
     }
 
+    @Operation(summary = "팀 삭제", description = "팀 리더만이 팀을 삭제할 수 있습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀 삭제 성공", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 팀이거나, 삭제를 요청한 사용자가 팀 리더가 아니면 팀 삭제 불가", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생", content = @Content(schema = @Schema(implementation = Exception.class)))
+    })
     @DeleteMapping("/delete/{ownerId}/{teamId}")
     public ResponseEntity<?> delete(@PathVariable @Valid @Positive(message = "사용자 아이디는 1 이상이어야 합니다.") Long ownerId,
                                     @PathVariable @Valid @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId) {

--- a/src/main/java/com/studycrew/studycrew_backend/api/team/TeamManagementController.java
+++ b/src/main/java/com/studycrew/studycrew_backend/api/team/TeamManagementController.java
@@ -30,7 +30,7 @@ public class TeamManagementController {
         return ResponseEntity.ok(teamDto);
     }
 
-    @PostMapping("/delete/{ownerId}/{teamId}")
+    @DeleteMapping("/delete/{ownerId}/{teamId}")
     public ResponseEntity<?> delete(@PathVariable @Valid @Positive(message = "사용자 아이디는 1 이상이어야 합니다.") Long ownerId,
                                     @PathVariable @Valid @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId) {
         teamManagementService.delete(ownerId, teamId);

--- a/src/main/java/com/studycrew/studycrew_backend/api/team/TeamMembershipController.java
+++ b/src/main/java/com/studycrew/studycrew_backend/api/team/TeamMembershipController.java
@@ -24,7 +24,7 @@ public class TeamMembershipController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/register/{teamId}/{userId}")
+    @PostMapping("/remove/{teamId}/{userId}")
     public ResponseEntity<?> removeUserFromTeam(@PathVariable @Valid @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId,
                                                 @PathVariable @Valid @Positive(message = "사용자 아이디는 1 이상이어야 합니다.") Long userId) {
         teamMembershipService.removeMemberFromTeam(teamId, userId);

--- a/src/main/java/com/studycrew/studycrew_backend/api/team/TeamMembershipController.java
+++ b/src/main/java/com/studycrew/studycrew_backend/api/team/TeamMembershipController.java
@@ -2,6 +2,12 @@ package com.studycrew.studycrew_backend.api.team;
 
 import com.studycrew.studycrew_backend.domain.profile.team.dto.TeamLeaderChangeRequestDto;
 import com.studycrew.studycrew_backend.domain.profile.team.service.TeamMembershipService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Team Membership Controller", description = "팀 가입, 탈퇴 및 팀 리더 변경 API 제공")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/membership")
@@ -17,6 +24,12 @@ public class TeamMembershipController {
 
     private final TeamMembershipService teamMembershipService;
 
+    @Operation(summary = "팀 가입", description = "크루 인원이 모두 차지 않았다면 팀 가입이 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀 가입 성공", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "400", description = "크루 인원이 모두 채워졌거나, 해당 사용자가 다른 팀에 가입된 상태라면 팀 가입 불가", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생", content = @Content(schema = @Schema(implementation = Exception.class)))
+    })
     @PostMapping("/register/{teamId}/{userId}")
     public ResponseEntity<?> addUserToTeam(@PathVariable @Valid @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId,
                                            @PathVariable @Valid @Positive(message = "사용자 아이디는 1 이상이어야 합니다.") Long userId) {
@@ -24,6 +37,12 @@ public class TeamMembershipController {
         return ResponseEntity.ok().body("팀에 추가되었습니다.");
     }
 
+    @Operation(summary = "팀 탈퇴", description = "크루이면서 팀 리더가 아니면 팀 탈퇴가 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀 탈퇴 성공", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "400", description = "팀 리더이거나 팀 멤버가 아니면 팀 탈퇴 불가", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생", content = @Content(schema = @Schema(implementation = Exception.class)))
+    })
     @DeleteMapping("/delete/{teamId}/{userId}")
     public ResponseEntity<?> removeUserFromTeam(@PathVariable @Valid @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId,
                                                 @PathVariable @Valid @Positive(message = "사용자 아이디는 1 이상이어야 합니다.") Long userId) {
@@ -31,6 +50,12 @@ public class TeamMembershipController {
         return ResponseEntity.ok().body("팀을 탈퇴했습니다.");
     }
 
+    @Operation(summary = "팀 리더 변경", description = "팀 리더만이 리더 변경 권한을 가지고 있으며, 팀 리더가 아닌 크루로 팀 리더 변경이 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "팀 리더 변경 성공", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "400", description = "팀 리더의 요청이 아니거나, 새로운 리더가 크루가 아니면 팀 리더 변경 불가", content = @Content(schema = @Schema(implementation = ResponseEntity.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생", content = @Content(schema = @Schema(implementation = Exception.class)))
+    })
     @PutMapping("/teams/{teamId}/leader")
     public ResponseEntity<?> changeTeamLeader(@PathVariable @Valid @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId,
                                               @RequestBody @Valid TeamLeaderChangeRequestDto teamLeaderChangeRequestDto) {

--- a/src/main/java/com/studycrew/studycrew_backend/api/team/TeamMembershipController.java
+++ b/src/main/java/com/studycrew/studycrew_backend/api/team/TeamMembershipController.java
@@ -21,20 +21,20 @@ public class TeamMembershipController {
     public ResponseEntity<?> addUserToTeam(@PathVariable @Valid @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId,
                                            @PathVariable @Valid @Positive(message = "사용자 아이디는 1 이상이어야 합니다.") Long userId) {
         teamMembershipService.addMemberToTeam(teamId, userId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body("팀에 추가되었습니다.");
     }
 
-    @PostMapping("/remove/{teamId}/{userId}")
+    @DeleteMapping("/delete/{teamId}/{userId}")
     public ResponseEntity<?> removeUserFromTeam(@PathVariable @Valid @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId,
                                                 @PathVariable @Valid @Positive(message = "사용자 아이디는 1 이상이어야 합니다.") Long userId) {
         teamMembershipService.removeMemberFromTeam(teamId, userId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body("팀을 탈퇴했습니다.");
     }
 
     @PutMapping("/teams/{teamId}/leader")
     public ResponseEntity<?> changeTeamLeader(@PathVariable @Valid @Positive(message = "팀 아이디는 1 이상이어야 합니다.") Long teamId,
                                               @RequestBody @Valid TeamLeaderChangeRequestDto teamLeaderChangeRequestDto) {
         teamMembershipService.changeLeader(teamId, teamLeaderChangeRequestDto);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body("팀 리더가 변겯외었습니다.");
     }
 }

--- a/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/dto/TeamDto.java
+++ b/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/dto/TeamDto.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class TeamDto {
 
@@ -75,12 +76,16 @@ public class TeamDto {
                 .endDate(team.getEndDate())
                 .teamSize(team.getTeamSize())
                 .teamStatus(team.getStatus())
+                .positions(team.getPositions())
+                .skills(team.getSkills())
                 .build();
     }
 
     private static List<UserSimpleProfileDto> convertUserSimpleProfileDtos(List<User> members) {
-        return members.stream()
-                .map(UserSimpleProfileDto::of)
-                .toList();
+        return Optional.ofNullable(members)
+                .map(list -> list.stream()
+                        .map(UserSimpleProfileDto::of)
+                        .toList())
+                .orElse(null);
     }
 }

--- a/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/dto/TeamDto.java
+++ b/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/dto/TeamDto.java
@@ -8,12 +8,14 @@ import com.studycrew.studycrew_backend.domain.tag.skill.SkillType;
 import com.studycrew.studycrew_backend.domain.tag.status.TeamStatus;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+@Getter
 public class TeamDto {
 
     private UserSimpleProfileDto leader;

--- a/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/dto/TeamDto.java
+++ b/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/dto/TeamDto.java
@@ -88,6 +88,6 @@ public class TeamDto {
                 .map(list -> list.stream()
                         .map(UserSimpleProfileDto::of)
                         .toList())
-                .orElse(null);
+                .orElse(new ArrayList<>());
     }
 }

--- a/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/dto/TeamLeaderChangeRequestDto.java
+++ b/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/dto/TeamLeaderChangeRequestDto.java
@@ -1,5 +1,6 @@
 package com.studycrew.studycrew_backend.domain.profile.team.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -9,9 +10,11 @@ public class TeamLeaderChangeRequestDto {
 
     @NotNull(message = "기존 팀 리더 아이디는 필수입니다.")
     @Min(value = 1, message = "사용자 아이디는 1 이상이어야 합니다.")
+    @Schema(description = "현재 팀 리더 ID", defaultValue = "1")
     private Long nowLeaderId;
 
     @NotNull(message = "새로운 팀 리더 아이디는 필수입니다.")
     @Min(value = 1, message = "사용자 아이디는 1 이상이어야 합니다.")
+    @Schema(description = "새로운 팀 리더 ID (크루 ID)", defaultValue = "2")
     private Long newLeaderId;
 }

--- a/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/dto/TeamRegistrationDto.java
+++ b/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/dto/TeamRegistrationDto.java
@@ -1,5 +1,7 @@
 package com.studycrew.studycrew_backend.domain.profile.team.dto;
 
+import com.studycrew.studycrew_backend.domain.tag.position.PositionType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -13,33 +15,48 @@ public class TeamRegistrationDto {
 
     @NotNull(message = "팀 리더 아이디는 필수입니다.")
     @Min(value = 1, message = "팀 리더 아이디는 1 이상이어야 합니다.")
+    @Schema(description = "팀 리더 ID", defaultValue = "1")
     private Long leaderId;
 
     @NotBlank(message = "팀명은 필수입니다.")
+    @Schema(description = "팀명", defaultValue = "크루 매칭 프로젝트 팀")
     private String name;
 
+    @Schema(description = "팀 설명")
     private String description;
 
     @NotBlank(message = "온라인/오프라인 선택은 필수입니다.")
+    @Schema(description = "미팅 모드 (온/오프라인)", defaultValue = "ONLINE")
     private String meetingMode;
 
     @NotNull(message = "주간 미팅 수는 필수입니다.")
     @Min(value = 1, message = "주간 미팅은 1회 이상이어야 합니다.")
+    @Schema(description = "주간 미팅 횟수", defaultValue = "2")
     private Integer weeklyMeetingCount;
 
+    @Schema(description = "지역 (오프라인)")
     private String location;
 
     // TODO: 유효성 검사 추가 (과거 불가능)
+    @Schema(description = "팀 모집 시작일")
     private LocalDate startDate;
 
     // TODO: 유효성 검사 추가 (startDate 이후 날짜)
+    @Schema(description = "팀 모집 마감일")
     private LocalDate endDate;
 
     @NotNull(message = "크루 총 인원은 필수입니다.")
     @Min(value = 1, message = "인원은 1명 이상이어야 합니다.")
+    @Schema(description = "크루 총 인원", defaultValue = "3")
     private Integer teamSize;
 
+    @Schema(description = "팀에서 원하는 포지션 (BE, FE...)",
+            example = "[\"BACKEND\", \"FRONTEND\", \"IOS\"]",
+            type = "array")
     private List<String> positions;
 
+    @Schema(description = "팀에서 원하는 기술 스택 (Java, Kotlin, JavaScript...)",
+            example = "[\"JAVA\", \"REACT\", \"DOCKER\"]",
+            type = "array")
     private List<String> skills;
 }

--- a/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/service/TeamManagementService.java
+++ b/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/service/TeamManagementService.java
@@ -27,6 +27,13 @@ public class TeamManagementService {
         return TeamDto.of(team);
     }
 
+    public TeamDto findTeamById(Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new IllegalArgumentException("Team not found"));
+
+        return TeamDto.of(team);
+    }
+
     @Transactional
     public void delete(Long teamId, Long leaderId) {
         Team team = teamRepository.findByIdAndLeaderId(teamId, leaderId)

--- a/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/service/TeamMembershipService.java
+++ b/src/main/java/com/studycrew/studycrew_backend/domain/profile/team/service/TeamMembershipService.java
@@ -25,7 +25,7 @@ public class TeamMembershipService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         team.addMember(member);
-        // member.setTeam(team);
+        member.assignTeam(team);
     }
 
     @Transactional
@@ -37,7 +37,7 @@ public class TeamMembershipService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         team.removeMember(member);
-        // member.setTeam(null);
+        member.assignTeam(null);
     }
 
     // TODO: 팀 변경 권한은 리더만 가능 -> security 적용 여부 확인

--- a/src/main/java/com/studycrew/studycrew_backend/domain/profile/user/User.java
+++ b/src/main/java/com/studycrew/studycrew_backend/domain/profile/user/User.java
@@ -3,6 +3,7 @@ package com.studycrew.studycrew_backend.domain.profile.user;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.studycrew.studycrew_backend.domain.profile.team.Team;
 import com.studycrew.studycrew_backend.domain.profile.user.dto.UserRegistrationDto;
 import com.studycrew.studycrew_backend.domain.tag.skill.SkillType;
 
@@ -60,5 +61,16 @@ public class User {
 			.info(userRegistrationDto.getInfo())
 			.skills(userRegistrationDto.getSkills())
 			.build();
+	}
+
+	public void assignTeam(Team newTeam) {
+		if(newTeam == null) {
+			this.team = null;
+			return;
+		}
+		if(this.team != null) {
+			throw new IllegalArgumentException("User already has a team");
+		}
+		this.team = newTeam;
 	}
 }

--- a/src/main/java/com/studycrew/studycrew_backend/domain/profile/user/dto/UserSimpleProfileDto.java
+++ b/src/main/java/com/studycrew/studycrew_backend/domain/profile/user/dto/UserSimpleProfileDto.java
@@ -4,7 +4,9 @@ import com.studycrew.studycrew_backend.domain.profile.user.User;
 import com.studycrew.studycrew_backend.domain.tag.position.PositionType;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 public class UserSimpleProfileDto {
 
     private String username;

--- a/src/main/java/com/studycrew/studycrew_backend/exception/ExceptionCode.java
+++ b/src/main/java/com/studycrew/studycrew_backend/exception/ExceptionCode.java
@@ -1,0 +1,18 @@
+package com.studycrew.studycrew_backend.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않습니다."),
+    NOT_VALID(HttpStatus.BAD_REQUEST, "유효하지 않은 값입니다."),
+    ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST, "위반된 인수"),
+    CONSTRAINT_VIOLATION(HttpStatus.BAD_REQUEST, "제약 조건 위반");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/studycrew/studycrew_backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/studycrew/studycrew_backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,71 @@
+package com.studycrew.studycrew_backend.exception;
+
+import com.studycrew.studycrew_backend.exception.response.ExceptionResponse;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Objects;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        com.studycrew.studycrew_backend.exception.response.ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .code(String.valueOf(ExceptionCode.NOT_VALID))
+                .message(Objects.requireNonNull(ex.getBindingResult().getFieldError()).getDefaultMessage())
+                .build();
+
+        return new ResponseEntity<>(exceptionResponse, ExceptionCode.NOT_VALID.getHttpStatus());
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<?> handleConstraintViolationException(ConstraintViolationException e) {
+        ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .code(String.valueOf(ExceptionCode.CONSTRAINT_VIOLATION))
+                .message(e.getMessage())
+                .build();
+
+        return new ResponseEntity<>(exceptionResponse, ExceptionCode.CONSTRAINT_VIOLATION.getHttpStatus());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<?> handleIllegalArgumentException(IllegalArgumentException e) {
+        ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .code(String.valueOf(ExceptionCode.ILLEGAL_ARGUMENT))
+                .message(e.getMessage())
+                .build();
+
+        return new ResponseEntity<>(exceptionResponse, ExceptionCode.ILLEGAL_ARGUMENT.getHttpStatus());
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<?> handleEntityNotFoundException(EntityNotFoundException e) {
+        ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .code(String.valueOf(ExceptionCode.NOT_FOUND))
+                .message(e.getMessage())
+                .build();
+
+        return new ResponseEntity<>(exceptionResponse, ExceptionCode.NOT_FOUND.getHttpStatus());
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ExceptionCode exceptionCode) {
+        return ResponseEntity.status(exceptionCode.getHttpStatus())
+                .body(createExceptionResponse(exceptionCode));
+    }
+
+    private ExceptionResponse createExceptionResponse(ExceptionCode exceptionCode) {
+        return ExceptionResponse.builder()
+                .code(exceptionCode.name())
+                .message(exceptionCode.getMessage())
+                .build();
+    }
+}

--- a/src/main/java/com/studycrew/studycrew_backend/exception/response/ExceptionResponse.java
+++ b/src/main/java/com/studycrew/studycrew_backend/exception/response/ExceptionResponse.java
@@ -1,0 +1,12 @@
+package com.studycrew.studycrew_backend.exception.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExceptionResponse {
+
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
### Swagger 3 설정
- TeamManagementController, TeamMembershipController에 swagger 3 설정
- TeamRegistrationDto, TeamLeaderChangeRequestDto에 @Schema 설정

### 팀-사용자 할당/해제 로직 추가

* 팀-사용자 할당/해제를 위해 User 도메인에 assignTeam 메서드 추가했습니다.